### PR TITLE
Update dependencies and fix for newer version of config-file-provider…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,11 +28,11 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.12</version>
+        <version>2.19</version>
         <relativePath />
     </parent>
     <artifactId>pipeline-multibranch-defaults</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Multibranch with defaults</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Multibranch+Defaults+Plugin</url>
@@ -77,12 +77,12 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
-            <version>2.9</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>config-file-provider</artifactId>
-            <version>2.11</version>
+            <version>2.15.1</version>
         </dependency>
 
         <dependency>
@@ -94,46 +94,46 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.1</version>
+            <version>2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.3</version>
+            <version>2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps-global-lib</artifactId>
-            <version>2.1</version>
+            <version>2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.3</version>
+            <version>2.6</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.2</version>
+            <version>2.11</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.10</version>
+            <version>2.23</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.2</version>
+            <version>2.3</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -178,7 +178,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.6</version>
+            <version>2.9</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/DefaultsBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/DefaultsBinder.java
@@ -29,7 +29,8 @@ import hudson.model.*;
 import jenkins.model.Jenkins;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
-import org.jenkinsci.plugins.configfiles.groovy.GroovyScript;
+import org.jenkinsci.plugins.configfiles.ConfigFileStore;
+import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinitionDescriptor;
@@ -60,9 +61,9 @@ class DefaultsBinder extends FlowDefinition {
             throw new IllegalStateException("inappropriate context");
         }
 
-        ConfigProvider configProvider = ConfigProvider.getByIdOrNull(GroovyScript.class.getName());
-        if (configProvider != null) {
-            Config config = configProvider.getConfigById(PipelineBranchDefaultsProjectFactory.SCRIPT);
+        ConfigFileStore store = GlobalConfigFiles.get();
+        if (store != null) {
+            Config config = store.getById(PipelineBranchDefaultsProjectFactory.SCRIPT);
             if (config != null) {
                 return new CpsFlowDefinition(config.content, false).create(handle, listener, actions);
             }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/DefaultsBinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/DefaultsBinderTest.java
@@ -31,6 +31,8 @@ import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.ConfigFileStore;
+import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.jenkinsci.plugins.configfiles.groovy.GroovyScript;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -53,12 +55,15 @@ public class DefaultsBinderTest {
     @Rule
     public GitSampleRepoRule sampleGitRepo = new GitSampleRepoRule();
 
+
     @Test
     public void testDefaultJenkinsFile() throws Exception {
-        ConfigProvider configProvider = ConfigProvider.getByIdOrNull(GroovyScript.class.getName());
+        GlobalConfigFiles globalConfigFiles = r.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+        ConfigFileStore store = globalConfigFiles.get();
+
         Config config = new GroovyScript("Jenkinsfile", "Jenkinsfile", "",
             "semaphore 'wait'; node {checkout scm; echo readFile('file')}");
-        configProvider.save(config);
+        store.save(config);
 
         sampleGitRepo.init();
         sampleGitRepo.write("file", "initial content");
@@ -77,10 +82,12 @@ public class DefaultsBinderTest {
 
     @Test
     public void testDefaultJenkinsFileLoadFromWorkspace() throws Exception {
-        ConfigProvider configProvider = ConfigProvider.getByIdOrNull(GroovyScript.class.getName());
+        GlobalConfigFiles globalConfigFiles = r.jenkins.getExtensionList(GlobalConfigFiles.class).get(GlobalConfigFiles.class);
+        ConfigFileStore store = globalConfigFiles.get();
         Config config = new GroovyScript("Jenkinsfile", "Jenkinsfile", "",
             "semaphore 'wait'; node {checkout scm; load 'Jenkinsfile'}");
-        configProvider.save(config);
+        store.save(config);
+
 
         sampleGitRepo.init();
         sampleGitRepo.write("Jenkinsfile", "echo readFile('file')");


### PR DESCRIPTION
… which has significant changes

Updating plugins in Jenkins updated config-file-provider to a more recent version which breaks this plugin. I've updated the dependencies in the pom and made the code changes required (which whilst aren't big, took some tracking down) due to major changes in the API. Tests pass. Tested locally in Jenkins and working fine.