### PR TITLE
Add support for sandbox and custom config names

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/DefaultsBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/DefaultsBinder.java
@@ -58,13 +58,6 @@ class DefaultsBinder extends FlowDefinition {
         this.useSandbox = useSandbox;
     }
 
-    public Object readResolve() {
-        if (this.scriptId == null) {
-            this.scriptId = PipelineBranchDefaultsProjectFactory.SCRIPT;
-        }
-        return this;
-    }
-
     @Override
     public FlowExecution create(FlowExecutionOwner handle, TaskListener listener, List<? extends Action> actions) throws Exception {
         Jenkins jenkins = Jenkins.getInstance();

--- a/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory.java
@@ -29,9 +29,11 @@ import hudson.model.TaskListener;
 import jenkins.branch.MultiBranchProject;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
-import org.jenkinsci.plugins.workflow.multibranch.WorkflowBranchProjectFactory;
+import org.jenkinsci.plugins.workflow.multibranch.AbstractWorkflowBranchProjectFactory;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -39,16 +41,70 @@ import java.io.IOException;
 /**
  * Recognizes and builds by default {@code Jenkinsfile}.
  */
-public class PipelineBranchDefaultsProjectFactory extends WorkflowBranchProjectFactory {
+public class PipelineBranchDefaultsProjectFactory extends AbstractWorkflowBranchProjectFactory {
     public static final String SCRIPT = "Jenkinsfile";
 
+    private String scriptId = SCRIPT;
+    private Boolean useSandbox = false;
+
+    public Object readResolve() {
+        if (this.scriptId == null) {
+            this.scriptId = SCRIPT;
+        }
+        return this;
+    }
+
     @DataBoundConstructor
-    public PipelineBranchDefaultsProjectFactory() {
+    public PipelineBranchDefaultsProjectFactory() { }
+
+    /**
+     * Set the script ID which will be used to reference the config file
+     * management for the contents of a Jenkinsfile.
+     *
+     * @param scriptId The ID of the groovy script to read as a Jenkinsfile.
+     */
+    @DataBoundSetter
+    public void setScriptId(String scriptId) {
+        if(StringUtils.isEmpty(scriptId)) {
+            this.scriptId = SCRIPT;
+        } else {
+            this.scriptId = scriptId;
+        }
+    }
+
+    /**
+     * Get the script ID which will be used to read the Jenkinsfile from config
+     * file management.
+     *
+     * @return The Jenkinsfile script ID.
+     */
+    public String getScriptId() {
+        return scriptId;
+    }
+
+    /**
+     * Set whether or not a Jenkinsfile should run within a Groovy sandbox.
+     *
+     * @param useSandbox Set true to enable Groovy sandbox or false to run in
+     *                   Jenkins master runtime.
+     */
+    @DataBoundSetter
+    public void setUseSandbox(boolean useSandbox) {
+        this.useSandbox = useSandbox;
+    }
+
+    /**
+     * Get the current setting for whether or not to use a groovy sandbox.
+     *
+     * @return true if using a groovy sandbox is desired.
+     */
+    public boolean getUseSandbox() {
+        return this.useSandbox;
     }
 
     @Override
     protected FlowDefinition createDefinition() {
-        return new DefaultsBinder();
+        return new DefaultsBinder(scriptId, useSandbox);
     }
 
     @Override
@@ -58,22 +114,25 @@ public class PipelineBranchDefaultsProjectFactory extends WorkflowBranchProjectF
             public boolean isHead(Probe probe, TaskListener listener) throws IOException {
                 return true;
             }
+
+            @Override
+            public int hashCode() {
+                return getClass().hashCode();
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                return getClass().isInstance(obj);
+            }
         };
     }
 
     @Extension
-    public static class DescriptorDefaultImpl extends AbstractWorkflowBranchProjectFactoryDescriptor {
-
-        @Override
-        public boolean isApplicable(Class<? extends MultiBranchProject> clazz) {
-            return PipelineMultiBranchDefaultsProject.class.isAssignableFrom(clazz);
-        }
-
+    public static class DescriptorImpl extends AbstractWorkflowBranchProjectFactoryDescriptor {
         @Nonnull
         @Override
         public String getDisplayName() {
             return "by default " + SCRIPT;
         }
-
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory.java
@@ -45,14 +45,7 @@ public class PipelineBranchDefaultsProjectFactory extends AbstractWorkflowBranch
     public static final String SCRIPT = "Jenkinsfile";
 
     private String scriptId = SCRIPT;
-    private Boolean useSandbox = false;
-
-    public Object readResolve() {
-        if (this.scriptId == null) {
-            this.scriptId = SCRIPT;
-        }
-        return this;
-    }
+    private boolean useSandbox = false;
 
     @DataBoundConstructor
     public PipelineBranchDefaultsProjectFactory() { }

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory/config.jelly
@@ -24,6 +24,11 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core">
-    <!-- TODO alternately, hide the selector, as in LiterateMultibranchProject/configure-factory.jelly -->
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Script ID}" field="scriptId">
+        <f:textbox value="${instance.scriptId}" default="Jenkinsfile" />
+    </f:entry>
+    <f:entry title="${%Run default Jenkinsfile within Groovy sandbox}" field="useSandbox">
+        <f:checkbox name="useSandbox" checked="${instance.useSandbox}" default="false" />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory/help-scriptId.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory/help-scriptId.html
@@ -1,0 +1,4 @@
+<div>
+    The ID of the default <code>Jenkinsfile</code> to use from the global
+    Config File Management.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory/help-useSandbox.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory/help-useSandbox.html
@@ -1,0 +1,6 @@
+<div>
+    If enabled, the configured default <code>Jenkinsfile</code> will be run
+    within a Groovy sandbox.  This option is <b>strongly recommended</b> if the
+    Jenkinsfile is using <a href="https://jenkins.io/doc/pipeline/steps/workflow-cps/"><code>load</code>
+    to evaluate a groovy source file</a> from an SCM repository.
+</div>


### PR DESCRIPTION
This adds two options to the Jenkins UI for configuring pipeline multibranch with defaults.

1. Customizing the config file name to something other than  `Jenkinsfile`.
2. Enabling groovy sandbox on the default Jenkinsfile being run.

Additionally, with these new options using the `@DataBoundSetter`, Job DSL is now available for configuring these settings.

Example Job DSL:

```groovy
multibranchPipelineJob('example') {
    factory {
        pipelineBranchDefaultsProjectFactory {
            // The ID of the default Jenkinsfile to use from the global Config File Management.
            scriptId('Jenkinsfile')

            // If enabled, the configured default Jenkinsfile will be run within a Groovy sandbox.
            useSandbox(true)
        }
    }
}
```

See also:

- [JENKINS-43285][JENKINS-43285] jobdsl for pipeline multibranch defaults
- [JENKINS-41108][JENKINS-41108] Posibility to specify the name of jenkinsfile

[JENKINS-41108]: https://issues.jenkins-ci.org/browse/JENKINS-41108
[JENKINS-43285]: https://issues.jenkins-ci.org/browse/JENKINS-43285