### PR TITLE
v2.0 bump and upgrade dependencies to latest revisions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@ THE SOFTWARE.
         <java.level>8</java.level>
     </properties>
     <artifactId>pipeline-multibranch-defaults</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Multibranch with defaults</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Multibranch+Defaults+Plugin</url>
@@ -213,27 +213,18 @@ THE SOFTWARE.
     </dependencies>
     <build>
         <plugins>
-    <!--
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
+                    <!--
                     <loggers>
                         <org.jenkinsci.plugins.workflow.multibranch>FINE</org.jenkinsci.plugins.workflow.multibranch>
                     </loggers>
+                    -->
+                    <compatibleSinceVersion>2.0</compatibleSinceVersion>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-    -->
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -74,16 +74,100 @@ THE SOFTWARE.
         <jenkins.version>1.642.3</jenkins.version>
     </properties>
     <dependencies>
+    <!-- MINIMUM REQUIRED DEPENDENCIES -->
+        <!-- workflow-cps is a runtime dependency -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-multibranch</artifactId>
-            <version>2.9.2</version>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.23</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>config-file-provider</artifactId>
             <version>2.15.1</version>
         </dependency>
+        <!-- New versions of pipeline plugins use this workflow-api plugin; just noting here for when I upgrade in the future.
+        Runtime dependency
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.29</version>
+        </dependency>
+        Runtime dependency
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>2.2.8</version>
+        </dependency>
+        -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.9</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+    <!-- END REQUIRED DEPENDENCIES -->
+    <!-- UNNECESSARILY REQUIRED BY CREATING A NEW JOB TYPE -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-multibranch</artifactId>
+            <version>2.9.2</version>
+        </dependency>
+    <!-- END UNNECESSARILY REQUIRED DEPENDENCIES -->
+    <!-- REQUIRED BY TESTS -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>2.5.2</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- noted requirements for updating minimal dependencies
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+            <version>2.0.20</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-multibranch</artifactId>
+            <version>2.20</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-test-harness</artifactId>
+            <version>2.42</version>
+            <scope>test</scope>
+        </dependency>
+        -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>2.11</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+    <!-- END REQUIRED BY TESTS -->
+    <!-- UNNECESSARILY REQUIRED TEST DEPS BY CREATING A NEW JOB TYPE -->
+    <!--
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-folder</artifactId>
+            <version>6.6</version>
+            <scope>test</scope>
+        </dependency>
+    -->
+    <!-- END UNNECESSARILY REQUIRED BY TESTS -->
 
         <dependency>
             <groupId>com.cloudbees</groupId>
@@ -118,20 +202,6 @@ THE SOFTWARE.
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-support</artifactId>
-            <version>2.11</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-            <version>2.23</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
             <version>2.3</version>
             <classifier>tests</classifier>
@@ -139,18 +209,6 @@ THE SOFTWARE.
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <version>2.5.2</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
             <version>2.6</version>
             <scope>test</scope>
@@ -172,13 +230,6 @@ THE SOFTWARE.
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
             <version>2.6</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <version>2.9</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,13 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.19</version>
+        <version>3.19</version>
         <relativePath />
     </parent>
+    <properties>
+        <jenkins.version>2.130</jenkins.version>
+        <java.level>8</java.level>
+    </properties>
     <artifactId>pipeline-multibranch-defaults</artifactId>
     <version>1.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
@@ -70,77 +74,59 @@ THE SOFTWARE.
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-    <properties>
-        <jenkins.version>1.642.3</jenkins.version>
-    </properties>
     <dependencies>
     <!-- MINIMUM REQUIRED DEPENDENCIES -->
-        <!-- workflow-cps is a runtime dependency -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.23</version>
-            <classifier>tests</classifier>
+            <version>2.56</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-aggregator</artifactId>
+            <version>2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>config-file-provider</artifactId>
-            <version>2.15.1</version>
+            <version>3.2</version>
         </dependency>
-        <!-- New versions of pipeline plugins use this workflow-api plugin; just noting here for when I upgrade in the future.
-        Runtime dependency
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
             <version>2.29</version>
         </dependency>
-        Runtime dependency
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
             <version>2.2.8</version>
         </dependency>
-        -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.9</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
+            <version>2.25</version>
         </dependency>
     <!-- END REQUIRED DEPENDENCIES -->
-    <!-- UNNECESSARILY REQUIRED BY CREATING A NEW JOB TYPE -->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-multibranch</artifactId>
-            <version>2.9.2</version>
-        </dependency>
-    <!-- END UNNECESSARILY REQUIRED DEPENDENCIES -->
     <!-- REQUIRED BY TESTS -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.5.2</version>
+            <version>3.9.1</version>
+            <classifier>tests</classifier>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-        <!-- noted requirements for updating minimal dependencies
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>branch-api</artifactId>
-            <version>2.0.20</version>
+            <artifactId>git</artifactId>
+            <version>3.9.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-multibranch</artifactId>
-            <version>2.20</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>2.2.8</version>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -149,106 +135,85 @@ THE SOFTWARE.
             <version>2.42</version>
             <scope>test</scope>
         </dependency>
-        -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.11</version>
+            <version>2.20</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>2.20</version>
             <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-    <!-- END REQUIRED BY TESTS -->
-    <!-- UNNECESSARILY REQUIRED TEST DEPS BY CREATING A NEW JOB TYPE -->
-    <!--
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>cloudbees-folder</artifactId>
-            <version>6.6</version>
-            <scope>test</scope>
-        </dependency>
-    -->
-    <!-- END UNNECESSARILY REQUIRED BY TESTS -->
-
-        <dependency>
-            <groupId>com.cloudbees</groupId>
-            <artifactId>groovy-cps</artifactId>
-            <version>1.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.5</version>
+            <version>2.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps-global-lib</artifactId>
-            <version>2.5</version>
+            <version>2.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.22</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>1.26.1</version>
+            <scope>test</scope>
+        </dependency>
+    <!-- END REQUIRED BY TESTS -->
+    <!-- UNNECESSARILY REQUIRED BY CREATING A NEW JOB TYPE -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-multibranch</artifactId>
+            <version>2.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+            <version>2.0.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloudbees-folder</artifactId>
+            <version>6.6</version>
+        </dependency>
+    <!-- END UNNECESSARILY REQUIRED DEPENDENCIES -->
+    <!-- UNNECESSARILY REQUIRED TEST DEPS BY CREATING A NEW JOB TYPE -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.18</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>ssh-credentials</artifactId>
+            <version>1.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.6</version>
-            <classifier>tests</classifier>
+            <version>2.16</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-scm-step</artifactId>
-            <version>2.3</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>subversion</artifactId>
-            <version>2.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <version>2.5.2</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>subversion</artifactId>
-            <version>2.6</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.modules</groupId>
-            <artifactId>sshd</artifactId>
-            <version>1.6</version>
-            <scope>test
-            </scope><!-- from git-server via workflow-cps-global-lib and otherwise unavailable during tests -->
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-auth</artifactId>
-            <version>1.4</version>
-            <scope>test</scope>
-        </dependency>
+    <!-- END UNNECESSARILY REQUIRED BY TESTS -->
     </dependencies>
     <build>
         <plugins>
+    <!--
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
@@ -267,6 +232,13 @@ THE SOFTWARE.
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+    -->
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/DefaultsBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/DefaultsBinder.java
@@ -25,9 +25,12 @@
 package org.jenkinsci.plugins.pipeline.multibranch.defaults;
 
 import hudson.Extension;
-import hudson.model.*;
+import hudson.model.Action;
+import hudson.model.Descriptor;
+import hudson.model.DescriptorVisibilityFilter;
+import hudson.model.Queue;
+import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
-import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.ConfigFileStore;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
@@ -38,7 +41,6 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.jenkinsci.plugins.workflow.multibranch.WorkflowBranchProjectFactory;
 
 import java.util.List;
 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.pipeline.multibranch.defaults;
 
 import hudson.Extension;
 import hudson.model.TaskListener;
-import jenkins.branch.MultiBranchProject;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
 import org.apache.commons.lang.StringUtils;


### PR DESCRIPTION
- Bump version to 2.0 (and annotate compatible since 2.0).  Mainly because the next release will include some irreversible configuration changes.
- Remove unused imports from classes.
- Expand wildcard imports in classes to be explicit imports.
- Re-organize pom.xml by what is necessary vs what is added to support the new job type provided (later, this job type will be removed).
- Upgrade parent pom to latest.
- Upgrade dependencies to latest revisions.