### PR TITLE
Use GitHub as a source of plugin documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
     <version>2.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Multibranch with defaults</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Multibranch+Defaults+Plugin</url>
+    <url>https://github.com/jenkinsci/pipeline-multibranch-defaults-plugin</url>
     <description>Enhances Pipeline plugin to handle branches better by automatically grouping builds from different
         branches. Supports enable one default pipeline
     </description>


### PR DESCRIPTION
Now we can use GitHub directly on the plugin site: https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/