### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineBranchDefaultsProjectFactory.java
@@ -25,6 +25,7 @@
 
 package org.jenkinsci.plugins.pipeline.multibranch.defaults;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.TaskListener;
 import jenkins.scm.api.SCMSource;
@@ -35,7 +36,6 @@ import org.jenkinsci.plugins.workflow.multibranch.AbstractWorkflowBranchProjectF
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 
 /**
@@ -122,7 +122,7 @@ public class PipelineBranchDefaultsProjectFactory extends AbstractWorkflowBranch
 
     @Extension
     public static class DescriptorImpl extends AbstractWorkflowBranchProjectFactoryDescriptor {
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "by default " + SCRIPT;

--- a/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineMultiBranchDefaultsProject.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineMultiBranchDefaultsProject.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.pipeline.multibranch.defaults;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;
@@ -31,8 +32,6 @@ import jenkins.branch.BranchProjectFactory;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
-
-import javax.annotation.Nonnull;
 
 /**
  * Representation of a set of workflows keyed off of source branches.
@@ -44,7 +43,7 @@ public class PipelineMultiBranchDefaultsProject extends WorkflowMultiBranchProje
         super(parent, name);
     }
 
-    @Nonnull
+    @NonNull
     protected BranchProjectFactory<WorkflowJob, WorkflowRun> newProjectFactory() {
         return new PipelineBranchDefaultsProjectFactory();
     }
@@ -52,7 +51,7 @@ public class PipelineMultiBranchDefaultsProject extends WorkflowMultiBranchProje
     @Extension
     public static class DescriptorImpl extends WorkflowMultiBranchProject.DescriptorImpl {
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return DefaultsMessages.PipelineMultiBranchDefaultsProject_DisplayName();

--- a/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineMultiBranchDefaultsProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineMultiBranchDefaultsProjectFactory.java
@@ -25,6 +25,7 @@
 
 package org.jenkinsci.plugins.pipeline.multibranch.defaults;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Action;
 import hudson.model.Item;
@@ -43,7 +44,6 @@ import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -165,7 +165,7 @@ public class PipelineMultiBranchDefaultsProjectFactory extends MultiBranchProjec
             return null;
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "by default " + SCRIPT;

--- a/src/test/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineMultiBranchDefaultsProjectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/multibranch/defaults/PipelineMultiBranchDefaultsProjectTest.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.pipeline.multibranch.defaults;
 
 import com.cloudbees.hudson.plugins.folder.computed.FolderComputation;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.plugins.pipeline.multibranch.defaults.PipelineBranchDefaultsProjectFactory;
 import org.jenkinsci.plugins.pipeline.multibranch.defaults.PipelineMultiBranchDefaultsProject;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -32,8 +33,6 @@ import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import javax.annotation.Nonnull;
 
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertTrue;
@@ -53,15 +52,15 @@ public class PipelineMultiBranchDefaultsProjectTest {
 
 
     public static
-    @Nonnull
-    WorkflowJob scheduleAndFindBranchProject(@Nonnull WorkflowMultiBranchProject mp, @Nonnull String name) throws Exception {
+    @NonNull
+    WorkflowJob scheduleAndFindBranchProject(@NonNull WorkflowMultiBranchProject mp, @NonNull String name) throws Exception {
         mp.scheduleBuild2(0).getFuture().get();
         return findBranchProject(mp, name);
     }
 
     public static
-    @Nonnull
-    WorkflowJob findBranchProject(@Nonnull WorkflowMultiBranchProject mp, @Nonnull String name) throws Exception {
+    @NonNull
+    WorkflowJob findBranchProject(@NonNull WorkflowMultiBranchProject mp, @NonNull String name) throws Exception {
         WorkflowJob p = mp.getItem(name);
         showIndexing(mp);
         if (p == null) {
@@ -70,7 +69,7 @@ public class PipelineMultiBranchDefaultsProjectTest {
         return p;
     }
 
-    static void showIndexing(@Nonnull WorkflowMultiBranchProject mp) throws Exception {
+    static void showIndexing(@NonNull WorkflowMultiBranchProject mp) throws Exception {
         FolderComputation<?> indexing = mp.getIndexing();
         System.out.println("---%<--- " + indexing.getUrl());
         indexing.writeWholeLogTo(System.out);


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
