### PR TITLE
Test with Java 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,6 @@
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 25],
+    [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,12 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.76</version>
+        <version>6.2132.v968a_e56c6941</version>
         <relativePath />
     </parent>
     <properties>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.baseline>2.516</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     </properties>
     <artifactId>pipeline-multibranch-defaults</artifactId>
     <version>2.2-SNAPSHOT</version>
@@ -75,8 +76,8 @@ THE SOFTWARE.
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>6055.v35edb_dc8d0f9</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
## Test with Java 25

Java 25 released September 16, 2025.  Jenkins core (weekly) has supported Java 25 since Jenkins 2.534, Oct 28, 2025.  Jenkins core (LTS) has supported Java 25 since 2.541.1, Jan 21, 2026.  90% of the 250 most popular plugin repositories now compile and test with Java 25.

Compile and test on ci.jenkins.io with Java 25 and Java 21.

Intentionally continues to generate Java 17 byte code as configured by the plugin parent pom.

Does not compile or test with Java 17. We have found no issues in the past that were specific to the Java 17 compiler.  Java 17 support has been dropped from Jenkins weekly and will be dropped from Jenkins LTS in April 2026.

Pull request includes other changes necessary to support Java 25:

* Use parent pom 6.2132.v968a_e56c6941
* Require Jenkins 2.516.3 or newer as recommended by [Jenkins documentation](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/)

### Testing done

* Confirmed that automated tests pass with Java 25 on Linux

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
